### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,6 @@ requests can be made using GitHub's `issues system`_.
    :target: https://travis-ci.org/shendo/taskq
    :alt: Current build status
 
-.. |pypi_version| image:: https://pypip.in/v/taskq/badge.png
+.. |pypi_version| image:: https://img.shields.io/pypi/v/taskq.svg
    :target: https://pypi.python.org/pypi/taskq
    :alt: Latest PyPI version


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20taskq))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `taskq`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.